### PR TITLE
Add `enabled-features` fn

### DIFF
--- a/src/hyak/core.clj
+++ b/src/hyak/core.clj
@@ -161,3 +161,11 @@
      (any? akey))))
 
 (def disabled? (complement enabled?))
+
+(defn enabled-features
+  "Get the set of all enabled features. Useful for dumping to a clojurescript
+  front-end statically."
+  [fstore akey]
+  (let [known-features (features fstore)
+        enabled-for-akey? (fn [fkey] (enabled? fstore fkey akey))]
+    (into #{} (filter enabled-for-akey?) known-features)))


### PR DESCRIPTION
Some parts of the system may not have live access to redis (eg. a
Clojurescript front end). This commit provides an easy way to get the
set of all features for a given akey as data (versus checking them
individually with `enabled?` ... the set itself can act as that
predicate via a simple membership check).