### PR TITLE
Revise group gates, housekeeping

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-java@v3.3.0
+      - uses: actions/setup-java@v3.4.1
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -16,7 +16,7 @@ jobs:
       - uses: supercharge/redis-github-action@1.4.0
         with:
           redis-version: 6
-      - uses: actions/cache@v3.0.4
+      - uses: actions/cache@v3.0.5
         env:
           cache-name: maven-cache
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ REDIS_URL ?= redis://localhost:6379/1
 
 # run test suite
 test:
-	REDIS_URL=$(REDIS_URL) clojure -A:test -m kaocha.runner
+	REDIS_URL=$(REDIS_URL) clojure -A:test -M -m kaocha.runner
 .PHONY: test
 
 # start a clojure repl with nrepl and local redis
 repl:
-	REDIS_URL=$(REDIS_URL) clj -A:test -Sdeps '{:deps {nrepl {:mvn/version "RELEASE"} cider/cider-nrepl {:mvn/version "RELEASE"} cider/piggieback {:mvn/version "RELEASE"}}}' -m nrepl.cmdline --middleware '[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]' --interactive --color
+	REDIS_URL=$(REDIS_URL) clj -A:test -Sdeps '{:deps {nrepl/nrepl {:mvn/version "RELEASE"} cider/cider-nrepl {:mvn/version "RELEASE"} cider/piggieback {:mvn/version "RELEASE"}}}' -M -m nrepl.cmdline --middleware '[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]' --interactive --color
 
 # fix formatting
 cljfmt:

--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,6 @@
  :deps {com.taoensso/carmine {:mvn/version "3.2.0-alpha1"}}
  :aliases
  {:test
-  {:extra-deps {lambdaisland/kaocha    {:mvn/version "1.66.1034"}
+  {:extra-deps {lambdaisland/kaocha    {:mvn/version "1.68.1059"}
                 org.clojure/test.check {:mvn/version "1.1.1"}}
    :extra-paths ["test"]}}}

--- a/test/hyak/core_test.clj
+++ b/test/hyak/core_test.clj
@@ -78,7 +78,7 @@
 (deftest group-test
   (let [admin-akeys    (gen/sample gen/string 5)
         non-admin-akey (gen/sample gen/string 5)
-        admin?         (set admin-akeys)
+        admin?         (fn [_fkey akey] ((set admin-akeys) akey))
         fkey           (make-fkey "group_feature")]
     (sut/register-group! :admins admin?)
     (doseq [admin-akey admin-akeys] (is (sut/disabled? fstore fkey admin-akey)))


### PR DESCRIPTION
- Implement group gates fkey -> akey -> Boolean
- Fix -M -m warning
- Run `antq --upgrade`, bump kaocha etc and github actions

It's potentially useful to set up the group gates as a function of both the flipper key and the actor key. (My initial use-case is just logging checks for debugging in prd; I know it's redundant with just setting an individual flipper group gate on or off).